### PR TITLE
Fix the problem when generating TOC for document with UTF-8 characters

### DIFF
--- a/markdown-toc.el
+++ b/markdown-toc.el
@@ -106,7 +106,7 @@
   (format "[%s](#%s)" title
           (->> title
                downcase
-               (replace-regexp-in-string "[^a-z0-9 -]" "")
+               (replace-regexp-in-string "[[:punct:]]" "")
                (s-replace " " "-"))))
 
 (defun markdown-toc--to-markdown-toc (level-title-toc-list)


### PR DESCRIPTION
```elisp
(replace-regexp-in-string "[^a-z0-9 -]" "")
```
will replace all UTF-8 characters to null string. Then the links in GitHub is not working.

```elisp
(replace-regexp-in-string "[[:punct:]]" "") 
```
can solve this problem, and is compatible with previous method.