### PR TITLE
Add option to change list item marker

### DIFF
--- a/markdown-toc.el
+++ b/markdown-toc.el
@@ -120,9 +120,17 @@
   (->> level-title-toc-list
        (--map (let ((nb-spaces (* 4 (car it)))
                     (title     (cdr it)))
-                (format "%s- %s" (markdown-toc--symbol " " nb-spaces)
+                (format "%s%s %s"
+                        (markdown-toc--symbol " " nb-spaces)
+                        markdown-toc-list-item-marker
                         (markdown-toc--to-link title))))
        (s-join "\n")))
+
+(defcustom markdown-toc-list-item-marker
+  "-"
+  "List item marker that should be used.
+Example: '-' for unordered lists or '1.' for ordered lists."
+  :group 'markdown-toc)
 
 (defcustom markdown-toc-header-toc-start
   "<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->"

--- a/markdown-toc.el
+++ b/markdown-toc.el
@@ -130,6 +130,9 @@
   "-"
   "List item marker that should be used.
 Example: '-' for unordered lists or '1.' for ordered lists."
+  :type '(choice
+          (string :tag "Unordered list header" "-")
+          (string :tag "Ordered list header" "1."))
   :group 'markdown-toc)
 
 (defcustom markdown-toc-header-toc-start


### PR DESCRIPTION
I added an option to the list item formatter that sets which list item marker is used in the TOC list. I added this feature because we use ordered lists to the table of contents in the private wiki pages we have in the company I work on. Never programmed elisp before (have some background on Clojure and Scheme though). Please, let me know if this change is not desired or if I did something wrong.