### PR TITLE
Adds utility functions for refresh and delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ markdown-toc
 
 [![Build Status](https://travis-ci.org/ardumont/markdown-toc.png?branch=master)](https://travis-ci.org/ardumont/markdown-toc) [![Coverage Status](https://coveralls.io/repos/ardumont/markdown-toc/badge.svg?branch=master&service=github)](https://coveralls.io/github/ardumont/markdown-toc?branch=master) [![MELPA Stable](http://stable.melpa.org/packages/markdown-toc-badge.svg)](http://stable.melpa.org/#/markdown-toc) [![MELPA](http://melpa.org/packages/markdown-toc-badge.svg)](http://melpa.org/#/markdown-toc)
 
-<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
 **Table of Contents**
 
 - [Use](#use)
@@ -11,6 +11,7 @@ markdown-toc
     - [User toc manipulation](#user-toc-manipulation)
     - [Update](#update)
     - [Create elsewhere](#create-elsewhere)
+    - [Remove](#remove)
     - [Customize](#customize)
 - [Install](#install)
     - [emacs package repository](#emacs-package-repository)
@@ -40,10 +41,13 @@ Inside a markdown file, the first time, place yourself where you want to insert 
 
 This will compute the TOC and insert it at current position.
 
+You can also execute: <kbd>M-x markdown-toc-generate-or-refres-toc</kbd> to either
+gnerate a TOC when none exists or refresh the currently existing one.
+
 Here is one possible output:
 
 ```markdown
-<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
 **Table of Contents**
 
 - [Use](#use)
@@ -108,16 +112,20 @@ Or drop all h1 titles... or whatever:
 
 ## Update
 
-To update the existing TOC, simply execute again:
-<kbd>C-u M-x markdown-toc-generate-toc</kbd>
+To update the existing TOC, simply execute:
+<kbd>M-x markdown-toc-refresh-toc</kbd>
 
 This will update the current TOC.
 
 ## Create elsewhere
 
-To create another updated TOC elsewhere, execute again <kbd>M-x
-markdown-toc-generate-toc</kbd>, this will remove the old TOC and
+To create another updated TOC elsewhere, execute <kbd>M-x
+markdown-toc-generate-toc</kbd> again, this will remove the old TOC and
 insert the updated one from where you stand.
+
+## Remove
+
+To remove a TOC, execute <kbd>M-x markdown-toc-delete-toc</kbd>.
 
 ## Customize
 

--- a/test/markdown-toc-test.el
+++ b/test/markdown-toc-test.el
@@ -91,7 +91,7 @@
 
 (ert-deftest markdown-toc--compute-full-toc ()
   (should (equal
-           "<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->\n**Table of Contents**\n\nsome-toc\n\n<!-- markdown-toc end -->\n"
+           "<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->\n**Table of Contents**\n\nsome-toc\n\n<!-- markdown-toc end -->\n"
            (markdown-toc--compute-full-toc "some-toc"))))
 
 (defmacro markdown-toc-with-temp-buffer-and-return-buffer-content (text body-test)
@@ -109,7 +109,7 @@ NB-LINES-FORWARD is the number of lines to get back to."
 
 ;; Create a new TOC
 (ert-deftest markdown-toc-generate-toc--first-toc ()
-  (should (equal "<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->
+  (should (equal "<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
 **Table of Contents**
 
 - [something](#something)
@@ -181,7 +181,7 @@ blahblah.
                     (markdown-toc-generate-toc))))))
 
 (ert-deftest markdown-toc-generate-toc--first-toc-with-user-override ()
-  (should (equal "<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->
+  (should (equal "<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
 **Table of Contents**
 
     - [Sources](#sources)
@@ -228,7 +228,7 @@ For this, you need to install a snippet of code in your emacs configuration file
                     (markdown-toc-generate-toc))))))
 
 (ert-deftest markdown-toc-generate-toc--replace-old-toc-if-already-present ()
-  (should (equal "<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->
+  (should (equal "<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
 **Table of Contents**
 
 - [Packages](#packages)
@@ -258,7 +258,7 @@ For this, you need to install a snippet of code in your emacs configuration file
 #### Tar
 "
                  (markdown-toc-with-temp-buffer-and-return-buffer-content
-                  "<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->
+                  "<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
 **Table of Contents**
 
     - [Melpa (~snapshot)](#melpa-snapshot)
@@ -289,7 +289,7 @@ For this, you need to install a snippet of code in your emacs configuration file
   ;; Update an existing TOC
   (should (equal "some foo bar before
 
-<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
 **Table of Contents**
 
 - [Packages](#packages)
@@ -321,7 +321,7 @@ For this, you need to install a snippet of code in your emacs configuration file
                  (markdown-toc-with-temp-buffer-and-return-buffer-content
                   "some foo bar before
 
-<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
 **Table of Contents**
 
     - [Melpa (~snapshot)](#melpa-snapshot)
@@ -348,6 +348,258 @@ For this, you need to install a snippet of code in your emacs configuration file
 "
                   (markdown-toc-generate-toc 'replace-old-toc)))))
 
+(ert-deftest test-markdown-toc-generate-or-refresh-toc--with-existing-toc ()
+  ;; Update an existing TOC
+  (should (equal "some foo bar before
+
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
+**Table of Contents**
+
+- [Packages](#packages)
+    - [Sources](#sources)
+        - [Marmalade (recommended)](#marmalade-recommended)
+        - [Melpa-stable](#melpa-stable)
+        - [Melpa (~snapshot)](#melpa-snapshot)
+    - [Install](#install)
+        - [Load org-trello](#load-org-trello)
+        - [Alternative](#alternative)
+            - [Git](#git)
+            - [Tar](#tar)
+
+<!-- markdown-toc end -->
+To install **org-trello** in your emacs, you need a few steps.
+# Packages
+## Sources
+If not already configured, you need to prepare emacs to work with marmalade or melpa.
+For this, you need to install a snippet of code in your emacs configuration file.
+### Marmalade (recommended)
+### Melpa-stable
+### Melpa (~snapshot)
+## Install
+### Load org-trello
+### Alternative
+#### Git
+#### Tar
+"
+                 (markdown-toc-with-temp-buffer-and-return-buffer-content
+                  "some foo bar before
+
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
+**Table of Contents**
+
+    - [Melpa (~snapshot)](#melpa-snapshot)
+    - [Install](#install)
+        - [Load org-trello](#load-org-trello)
+        - [Alternative](#alternative)
+            - [Git](#git)
+            - [Tar](#tar)
+
+<!-- markdown-toc end -->
+To install **org-trello** in your emacs, you need a few steps.
+# Packages
+## Sources
+If not already configured, you need to prepare emacs to work with marmalade or melpa.
+For this, you need to install a snippet of code in your emacs configuration file.
+### Marmalade (recommended)
+### Melpa-stable
+### Melpa (~snapshot)
+## Install
+### Load org-trello
+### Alternative
+#### Git
+#### Tar
+"
+                  (markdown-toc-generate-or-refresh-toc)))))
+
+(ert-deftest test-markdown-toc-generate-or-refresh-toc--without-existing-toc ()
+  (should (equal "<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
+**Table of Contents**
+
+- [something](#something)
+    - [Sources](#sources)
+        - [Marmalade (recommended)](#marmalade-recommended)
+        - [Melpa-stable](#melpa-stable)
+        - [Melpa (~snapshot)](#melpa-snapshot)
+        - [[配置 SPF Sender Policy Framework 记录]](#配置-spf-sender-policy-framework-记录)
+    - [Install](#install)
+        - [Load org-trello](#load-org-trello)
+        - [Alternative](#alternative)
+            - [Git](#git)
+            - [Tar](#tar)
+
+<!-- markdown-toc end -->
+To install **org-trello** in your emacs, you need a few steps.
+# something
+## Sources
+If not already configured, you need to prepare emacs to work with marmalade or melpa.
+For this, you need to install a snippet of code in your emacs configuration file.
+### Marmalade (recommended)
+### Melpa-stable
+### Melpa (~snapshot)
+### [配置 SPF Sender Policy Framework 记录]
+## Install
+### Load org-trello
+### Alternative
+#### Git
+#### Tar
+"
+                 (markdown-toc-with-temp-buffer-and-return-buffer-content
+                  "To install **org-trello** in your emacs, you need a few steps.
+# something
+## Sources
+If not already configured, you need to prepare emacs to work with marmalade or melpa.
+For this, you need to install a snippet of code in your emacs configuration file.
+### Marmalade (recommended)
+### Melpa-stable
+### Melpa (~snapshot)
+### [配置 SPF Sender Policy Framework 记录]
+## Install
+### Load org-trello
+### Alternative
+#### Git
+#### Tar
+"
+                  (markdown-toc-generate-or-refresh-toc)))))
+
+(ert-deftest test-markdown-toc--refresh-toc--with-existing-toc ()
+  ;; Update an existing TOC
+  (should (equal "some foo bar before
+
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
+**Table of Contents**
+
+- [Packages](#packages)
+    - [Sources](#sources)
+        - [Marmalade (recommended)](#marmalade-recommended)
+        - [Melpa-stable](#melpa-stable)
+        - [Melpa (~snapshot)](#melpa-snapshot)
+    - [Install](#install)
+        - [Load org-trello](#load-org-trello)
+        - [Alternative](#alternative)
+            - [Git](#git)
+            - [Tar](#tar)
+
+<!-- markdown-toc end -->
+To install **org-trello** in your emacs, you need a few steps.
+# Packages
+## Sources
+If not already configured, you need to prepare emacs to work with marmalade or melpa.
+For this, you need to install a snippet of code in your emacs configuration file.
+### Marmalade (recommended)
+### Melpa-stable
+### Melpa (~snapshot)
+## Install
+### Load org-trello
+### Alternative
+#### Git
+#### Tar
+"
+                 (markdown-toc-with-temp-buffer-and-return-buffer-content
+                  "some foo bar before
+
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
+**Table of Contents**
+
+    - [Melpa (~snapshot)](#melpa-snapshot)
+    - [Install](#install)
+        - [Load org-trello](#load-org-trello)
+        - [Alternative](#alternative)
+            - [Git](#git)
+            - [Tar](#tar)
+
+<!-- markdown-toc end -->
+To install **org-trello** in your emacs, you need a few steps.
+# Packages
+## Sources
+If not already configured, you need to prepare emacs to work with marmalade or melpa.
+For this, you need to install a snippet of code in your emacs configuration file.
+### Marmalade (recommended)
+### Melpa-stable
+### Melpa (~snapshot)
+## Install
+### Load org-trello
+### Alternative
+#### Git
+#### Tar
+"
+                  (markdown-toc-refresh-toc)))))
+
+(ert-deftest test-markdown-toc-refresh-toc--without-existing-toc ()
+  (should (equal "To install **org-trello** in your emacs, you need a few steps.
+# something
+## Sources
+If not already configured, you need to prepare emacs to work with marmalade or melpa.
+For this, you need to install a snippet of code in your emacs configuration file.
+### Marmalade (recommended)
+### Melpa-stable
+### Melpa (~snapshot)
+### [配置 SPF Sender Policy Framework 记录]
+## Install
+### Load org-trello
+### Alternative
+#### Git
+#### Tar
+"
+                 (markdown-toc-with-temp-buffer-and-return-buffer-content
+                  "To install **org-trello** in your emacs, you need a few steps.
+# something
+## Sources
+If not already configured, you need to prepare emacs to work with marmalade or melpa.
+For this, you need to install a snippet of code in your emacs configuration file.
+### Marmalade (recommended)
+### Melpa-stable
+### Melpa (~snapshot)
+### [配置 SPF Sender Policy Framework 记录]
+## Install
+### Load org-trello
+### Alternative
+#### Git
+#### Tar
+"
+                  (markdown-toc-refresh-toc)))))
+
+(ert-deftest test-markdown-toc-delete-toc ()
+  (should (equal "To install **org-trello** in your emacs, you need a few steps.
+# Packages
+## Sources
+If not already configured, you need to prepare emacs to work with marmalade or melpa.
+For this, you need to install a snippet of code in your emacs configuration file.
+### Marmalade (recommended)
+### Melpa-stable
+### Melpa (~snapshot)
+## Install
+### Load org-trello
+### Alternative
+#### Git
+#### Tar
+"
+                 (markdown-toc-with-temp-buffer-and-return-buffer-content
+                   "<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
+**Table of Contents**
+
+    - [Melpa (~snapshot)](#melpa-snapshot)
+    - [Install](#install)
+        - [Load org-trello](#load-org-trello)
+        - [Alternative](#alternative)
+            - [Git](#git)
+            - [Tar](#tar)
+
+<!-- markdown-toc end -->
+To install **org-trello** in your emacs, you need a few steps.
+# Packages
+## Sources
+If not already configured, you need to prepare emacs to work with marmalade or melpa.
+For this, you need to install a snippet of code in your emacs configuration file.
+### Marmalade (recommended)
+### Melpa-stable
+### Melpa (~snapshot)
+## Install
+### Load org-trello
+### Alternative
+#### Git
+#### Tar
+"
+                  (markdown-toc-delete-toc)))))
 
 (ert-deftest test-markdown-toc-log-msg ()
   (should (string= "markdown-toc - hello dude"


### PR DESCRIPTION
This PR ads some utility functions:

- `markdown-toc-delete-toc`: Delete a TOC from anywhere without losing cursor position.
- `markdown-toc-refresh-toc`: Refresh a TOC from anywhere without losing cursor position.
- `markdown-toc-generate-or-refresh-toc`: This is a one size fits all function to generate and refresh a TOC.

These are all for interactive usage. Also `markdown-toc-refresh-toc` can for example be used in a `before-save` hook for markdown files.

Let me know what you think about this PR!