### PR TITLE
Distinguishes between duplicate titles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 before_install:
   # evm install
   - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
+  - evm list
   - evm install $EVM_EMACS --use --skip
   # install the matrix's emacs version
   - cask --version
@@ -18,6 +19,12 @@ env:
     - EVM_EMACS=emacs-24.4-travis
     - EVM_EMACS=emacs-24.5-travis
     - EVM_EMACS=emacs-25.1-travis
+    - EVM_EMACS=emacs-25.2-travis
+    - EVM_EMACS=emacs-git-snapshot-travis
+
+matrix:
+  allow_failures:
+    - env: EVM_EMACS=emacs-git-snapshot-travis
 
 script:
   - pwd

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Inside a markdown file, the first time, place yourself where you want to insert 
 
 This will compute the TOC and insert it at current position.
 
-You can also execute: <kbd>M-x markdown-toc-generate-or-refres-toc</kbd> to either
+You can also execute: <kbd>M-x markdown-toc-generate-or-refresh-toc</kbd> to either
 gnerate a TOC when none exists or refresh the currently existing one.
 
 Here is one possible output:

--- a/test/markdown-toc-test.el
+++ b/test/markdown-toc-test.el
@@ -4,6 +4,10 @@
 (require 'mocker)
 (require 'cl)
 
+(ert-deftest test-markdown-toc-version ()
+  (let ((markdown-toc--toc-version "0.1.2"))
+    (should (equal "markdown-toc version: 0.1.2" (markdown-toc-version)))))
+
 (ert-deftest markdown-toc--symbol ()
   (should (equal "   "       (markdown-toc--symbol " " 3)))
   (should (equal "-#--#--#-" (markdown-toc--symbol "-#-" 3))))

--- a/test/markdown-toc-test.el
+++ b/test/markdown-toc-test.el
@@ -9,8 +9,10 @@
   (should (equal "-#--#--#-" (markdown-toc--symbol "-#-" 3))))
 
 (ert-deftest markdown-toc--to-link ()
+  (should (equal "[some markdown page~title (foo).](#some-markdown-pagetitle-foo-1)"
+            (markdown-toc--to-link "some markdown page~title (foo)." 1)))
   (should (equal "[some markdown page~title (foo).](#some-markdown-pagetitle-foo)"
-                 (markdown-toc--to-link "some markdown page~title (foo)."))))
+                 (markdown-toc--to-link "some markdown page~title (foo)." 0))))
 
 (ert-deftest markdown-toc--to-markdown-toc ()
   (should (equal "- [some markdown page title](#some-markdown-page-title)
@@ -142,6 +144,65 @@ For this, you need to install a snippet of code in your emacs configuration file
 "
                  (markdown-toc-with-temp-buffer-and-return-buffer-content
                   "To install **org-trello** in your emacs, you need a few steps.
+# something
+## Sources
+If not already configured, you need to prepare emacs to work with marmalade or melpa.
+For this, you need to install a snippet of code in your emacs configuration file.
+### Marmalade (recommended)
+### Melpa-stable
+### Melpa (~snapshot)
+### [配置 SPF Sender Policy Framework 记录]
+## Install
+### Load org-trello
+### Alternative
+#### Git
+#### Tar
+"
+                  (markdown-toc-generate-toc)))))
+
+(ert-deftest markdown-toc-generate-toc--with-duplicate-titles ()
+  (should (equal "<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
+**Table of Contents**
+
+- [something](#something)
+- [something](#something-1)
+- [something](#something-2)
+- [something](#something-3)
+    - [Sources](#sources)
+        - [Marmalade (recommended)](#marmalade-recommended)
+        - [Melpa-stable](#melpa-stable)
+        - [Melpa (~snapshot)](#melpa-snapshot)
+        - [[配置 SPF Sender Policy Framework 记录]](#配置-spf-sender-policy-framework-记录)
+    - [Install](#install)
+        - [Load org-trello](#load-org-trello)
+        - [Alternative](#alternative)
+            - [Git](#git)
+            - [Tar](#tar)
+
+<!-- markdown-toc end -->
+To install **org-trello** in your emacs, you need a few steps.
+# something
+# something
+# something
+# something
+## Sources
+If not already configured, you need to prepare emacs to work with marmalade or melpa.
+For this, you need to install a snippet of code in your emacs configuration file.
+### Marmalade (recommended)
+### Melpa-stable
+### Melpa (~snapshot)
+### [配置 SPF Sender Policy Framework 记录]
+## Install
+### Load org-trello
+### Alternative
+#### Git
+#### Tar
+"
+                 (markdown-toc-with-temp-buffer-and-return-buffer-content
+                  "To install **org-trello** in your emacs, you need a few steps.
+# something
+# something
+# something
 # something
 ## Sources
 If not already configured, you need to prepare emacs to work with marmalade or melpa.


### PR DESCRIPTION
Github, Gitlab, Gogs and other git hosting sites that parse a README.md file
and display it as HTML deal with duplicate header names by appending their
anchors with a number.

Note that this is just something I hacked one late evening and another early morning so I'm aware it's not the best implementation. Feel free to tell me how things can be improved.