### PR TITLE
fix : toc-style

### DIFF
--- a/markdown-toc.el
+++ b/markdown-toc.el
@@ -249,7 +249,7 @@ Return the end position if it exists, nil otherwise."
 
 (defun markdown-toc--compute-full-toc (toc)
   "Given the TOC's content, compute the full toc with comments and title."
-  (format "%s\n%s\n\n%s\n\n%s\n"
+  (format "%s\n\n%s\n\n%s\n\n%s\n"
           markdown-toc-header-toc-start
           markdown-toc-header-toc-title
           toc


### PR DESCRIPTION
Can we make this format as default ?

```
<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->

**Table of Contents**
...
```
When I use formatter like `pretty` to format md files ,  it always insert a space line between the start and title, of course I could set  `(setq markdown-toc-header-toc-title "\n**index of table**")` to solve issue. I guess others may has this trouble too
