### PR TITLE
Set default indentation to 2 spaces

### DIFF
--- a/markdown-toc.el
+++ b/markdown-toc.el
@@ -95,7 +95,7 @@ Example: '-' for unordered lists or '1.' for ordered lists."
   :group 'markdown-toc
   :type 'string)
 
-(defcustom markdown-toc-indentation-space 4
+(defcustom markdown-toc-indentation-space 2
   "Let the user decide the indentation level."
   :group 'markdown-toc
   :type 'integer)


### PR DESCRIPTION
Two spaces conforms with markdownlint. See markdownlint [rule MD007][1].

This is obviously easily configurable; I just thought I'd open this PR as a tiny point for consideration.

[1]: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md007

